### PR TITLE
feat: add support for ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,1 @@
-'use strict';
-
-exports.fullName = 'fhqwhgadshgnsdhjsdbkhsdabkfabkveybvf';
+export default { fullName: 'fhqwhgadshgnsdhjsdbkhsdabkfabkveybvf' };

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "fhqwhgads",
   "version": "1.0.0",
   "description": "Come on, fhqwhgads.",
+  "type": "module",
+  "exports": "./index.js",
   "main": "index.js",
   "scripts": {
-    "test": "semistandard"
+    "test": "semistandard && node test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,4 @@
+import fhqwhgads from './index.js';
+import assert from 'node:assert';
+
+assert.deepStrictEqual(fhqwhgads, { fullName: 'fhqwhgadshgnsdhjsdbkhsdabkfabkveybvf' });


### PR DESCRIPTION
This is so I can test semantic-release after removing a token.

BREAKING CHANGE: drop support for CommonJ